### PR TITLE
[8.0] website_sale_available: Fix multilang incompatibility in checkout button and added Spanish translations

### DIFF
--- a/website_sale_available/i18n/es.po
+++ b/website_sale_available/i18n/es.po
@@ -1,0 +1,23 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#   * website_sale_available
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 8.0-20130610-231029\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-02-10 12:00+0000\n"
+"PO-Revision-Date: \n"
+"Last-Translator: Pedro Albujer\n"
+"Language-Team: Diagram Software\n"
+"Language: Spanish\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+
+
+#. module: website_sale_available
+#: view:website:website_sale.cart
+msgid "Available"
+msgstr "Disponible"

--- a/website_sale_available/static/src/js/website_sale_available.js
+++ b/website_sale_available/static/src/js/website_sale_available.js
@@ -18,7 +18,7 @@ $(document).ready(function () {
             if (!enough)
                 available = false;
         })
-        $('a[href="/shop/checkout"]').toggleClass('disabled', !available);
+        $('a[href$="/shop/checkout"]').toggleClass('disabled', !available);
     }
     
     $(input_selector).on('change', function(){


### PR DESCRIPTION
When we use multiple languages in same website the checkout button in cart page is not disabled in secondary languages. It's because the button is selected using href and href value change with the language. Now with this fix are selected all href that finish with /shop/checkout